### PR TITLE
Pre-P0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install --upgrade git+https://github.com/richardliaw/track.git@master#egg=tr
 
 ## Usage
 
-Report various metrics of interest (if you launch within a git repository `myproject`, the local directory `~/track/myproject` is automatically inferred below).
+Report various metrics of interest, with automatically configured and persisted logging.
 
 ```
 import track 
@@ -22,9 +22,10 @@ def training_function(param1=0.01, param2=10):
             model.train()
             loss = model.get_loss()
             track.metric(iteration=epoch, loss=loss)
+            track.debug("epoch {} just finished with loss {}", epoch, loss)
 ```
         
-Inspect existing experiments (from anywhere, if you supply `--remote_dir`)
+Inspect existing experiments
 
 ```
 $ python -m track.trials --local_dir ~/track/myproject trial_id "start_time>2018-06-28" param2
@@ -32,7 +33,7 @@ trial_id    start_time                param2
 8424fb387a 2018-06-28 11:17:28.752259 10
 ```
 
-Plot results (from anywhere)
+Plot results
 
 ```
 import track
@@ -40,8 +41,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-remote_dir = "s3://my-track-bucket/myproject"
-proj = track.Project("~/track/myproject", remote_dir)
+proj = track.Project("~/track/myproject", "s3://my-track-bucket/myproject")
 most_recent = proj.ids["start_time"].idxmax()
 most_recent_id = proj.ids["trial_id"].iloc[[most_recent]]
 res = proj.results(most_recent_id)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `pip install track` (Not yet). Until we get pypi set up (there's another `track` package...), use
 
 ```
-pip install --upgrade https://github.com/richardliaw/track/archive/vlad-convenience.zip#egg=track
+pip install --upgrade git+https://github.com/richardliaw/track.git@vlad-convenience#egg=track
 ```
 
 ## Usage
@@ -13,14 +13,13 @@ pip install --upgrade https://github.com/richardliaw/track/archive/vlad-convenie
 ```
 import track 
 
-def training_function():
-    trial = track.Trial("~/results", "remote_dir")
-    trial.start()
-    for i in range(N):
-        # train model ...
-        trial.metric()
-        
-    trial.close()
+def training_function(param1=0.01, param2=10):
+    with track.trial("~/track/myproject", "s3://my-track-bucket/myproject"):
+        model = create_model()
+        for epoch in range(100):
+            model.train()
+            loss = model.get_loss()
+            track.metric(iteration=epoch, loss=loss)
 ```
         
     

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 `pip install track` (Not yet). Until we get pypi set up (there's another `track` package...), use
 
 ```
-pip install --upgrade git+https://github.com/richardliaw/track.git@vlad-convenience#egg=track
+pip install --upgrade git+https://github.com/richardliaw/track.git@master#egg=track
 ```
 
 ## Usage
 
-Report various metrics of interest.
+Report various metrics of interest (if you launch within a git repository `myproject`, the local directory `~/track/myproject` is automatically inferred below).
 
 ```
 import track 
@@ -24,3 +24,27 @@ def training_function(param1=0.01, param2=10):
             track.metric(iteration=epoch, loss=loss)
 ```
         
+Inspect existing experiments (from anywhere, if you supply `--remote_dir`)
+
+```
+$ python -m track.trials --local_dir ~/track/myproject trial_id "start_time>2018-06-28" param2
+trial_id    start_time                param2
+8424fb387a 2018-06-28 11:17:28.752259 10
+```
+
+Plot results (from anywhere)
+
+```
+import track
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+remote_dir = "s3://my-track-bucket/myproject"
+proj = track.Project("~/track/myproject", remote_dir)
+most_recent = proj.ids["start_time"].idxmax()
+most_recent_id = proj.ids["trial_id"].iloc[[most_recent]]
+res = proj.results(most_recent_id)
+plt.plot(res["loss"].dropna())
+plt.savefig("loss.png")
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `pip install track` (Not yet). Until we get pypi set up (there's another `track` package...), use
 
 ```
-pip install --upgrade git+git://github.com/richardliaw/track.git#egg=track
+pip install https://github.com/richardliaw/track/archive/vlad-convenience.zip#egg=track
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ pip install --upgrade git+https://github.com/richardliaw/track.git@vlad-convenie
 
 ## Usage
 
+Report various metrics of interest.
+
 ```
 import track 
 
@@ -22,4 +24,3 @@ def training_function(param1=0.01, param2=10):
             track.metric(iteration=epoch, loss=loss)
 ```
         
-    

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `pip install track` (Not yet). Until we get pypi set up (there's another `track` package...), use
 
 ```
-pip install https://github.com/richardliaw/track/archive/vlad-convenience.zip#egg=track
+pip install --upgrade https://github.com/richardliaw/track/archive/vlad-convenience.zip#egg=track
 ```
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 from setuptools import setup
 
+install_requires = [
+    "pandas>=0.20.1"
+]
+
 setup(
     name="track",
     author="RISE",
+    install_requires=install_requires,
     packages=["track"],
     package_dir={"track": "track"}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup
 
 install_requires = [
-    "pandas>=0.20.1"
+    "pandas>=0.20.1",
+    'absl-py>=0.1.13',
 ]
 
 setup(

--- a/track/__init__.py
+++ b/track/__init__.py
@@ -53,10 +53,10 @@ def trial(log_dir=None,
 
 def metric(*, iteration=None, **kwargs):
     """Applies Trial.metric to the trial in the current context."""
-    _trial.metric(iteration=iteration, **kwargs)
+    return _trial.metric(iteration=iteration, **kwargs)
 
-def artifact(artifact_name, src):
-    """Applies Trial.artifact to the trial in the current context."""
-    _trial.artifact(artifact_name, src)
+def artifact_directory():
+    """Applies Trial.artifact_directory to the trial in the current context."""
+    return _trial.artifact_directory()
 
 __all__ = ["Trial", "Project", "trial", "absl_flags", "debug"]

--- a/track/__init__.py
+++ b/track/__init__.py
@@ -12,6 +12,14 @@ from .convenience import absl_flags
 # a thread-local stack. Def doable but annoying.
 _trial = None
 
+# TODO: make this (or Trial) an actual context manager class
+# so we can properly detect if an exception was thrown,
+# in which case the fact that we errored can get logged
+# appropriately (i.e., don't close cleanly).
+# TODO: simplify API: only need one of track() or Trial()
+# I like the idea of not having a trial object at all that
+# the user ever deals with, and instead keeping everything
+# implicit.
 @contextmanager
 def trial(log_dir="~/ray_results/project_name",
           upload_dir=None,
@@ -34,7 +42,7 @@ def trial(log_dir="~/ray_results/project_name",
     try:
         _trial = local_trial
         _trial.start()
-        yield
+        yield local_trial
     finally:
         _trial = None
         local_trial.close()

--- a/track/__init__.py
+++ b/track/__init__.py
@@ -21,12 +21,15 @@ _trial = None
 # the user ever deals with, and instead keeping everything
 # implicit.
 @contextmanager
-def trial(log_dir="~/ray_results/project_name",
+def trial(log_dir=None,
           upload_dir=None,
           sync_period=None,
           trial_prefix="",
-          param_map=None):
-    """Generates a trial within a with context"""
+          param_map=None,
+          init_logging=True):
+    """
+    Generates a trial within a with context.
+    """
     global _trial  # pylint: disable=global-statement
     if _trial:
         # TODO: would be nice to stack crawl at creation time to report

--- a/track/__init__.py
+++ b/track/__init__.py
@@ -1,7 +1,8 @@
 from contextlib import contextmanager
 
-from track.trial import Trial
-from track.project import Project
+from .trial import Trial
+from .project import Project
+from .convenience import absl_flags
 
 # TODO: note that this might get icky when the user
 # forks or uses multiple threads. The latter can be
@@ -46,4 +47,4 @@ def artifact(artifact_name, src):
     """Applies Trial.artifact to the trial in the current context."""
     _trial.artifact(artifact_name, src)
 
-__all__ = ["Trial", "Project", "trial"]
+__all__ = ["Trial", "Project", "trial", "absl_flags"]

--- a/track/__init__.py
+++ b/track/__init__.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 from .trial import Trial
 from .project import Project
+from .log import debug
 from .convenience import absl_flags
 
 # TODO: note that this might get icky when the user
@@ -58,4 +59,4 @@ def artifact(artifact_name, src):
     """Applies Trial.artifact to the trial in the current context."""
     _trial.artifact(artifact_name, src)
 
-__all__ = ["Trial", "Project", "trial", "absl_flags"]
+__all__ = ["Trial", "Project", "trial", "absl_flags", "debug"]

--- a/track/__init__.py
+++ b/track/__init__.py
@@ -55,8 +55,9 @@ def metric(*, iteration=None, **kwargs):
     """Applies Trial.metric to the trial in the current context."""
     return _trial.metric(iteration=iteration, **kwargs)
 
-def artifact_directory():
-    """Applies Trial.artifact_directory to the trial in the current context."""
-    return _trial.artifact_directory()
+def trial_dir():
+    """Retrieves the trial directory for the trial in the current context."""
+    return _trial.trial_dir()
 
-__all__ = ["Trial", "Project", "trial", "absl_flags", "debug"]
+__all__ = ["Trial", "Project", "trial", "absl_flags", "debug", "metric",
+           "trial_dir"]

--- a/track/autodetect.py
+++ b/track/autodetect.py
@@ -1,0 +1,39 @@
+"""
+Hacky, library and usage specific tricks to infer decent defaults.
+"""
+import os
+import subprocess
+import sys
+
+def dfl_local_dir():
+    """
+    Infers a default local directory, which is ~/track/<project name>,
+    where the project name is guessed according to the following rules.
+
+    If we detect we're in a repository, the project name is the repository name
+    (git only for now).
+
+    If we're not in a repository, and the script file sys.argv[0] is non-null,
+    then that is used.
+
+    Otherwise, we just say it's "unknown"
+    """
+    project_name = git_repo()
+    if not project_name and sys.argv:
+        project_name = sys.argv[0]
+    if not project_name:
+        project_name = "unknown"
+    dirpath = os.path.join("~", "track", project_name)
+    return os.path.expanduser(dirpath)
+
+def git_repo():
+    """
+    Returns the git repository root if the cwd is in a repo, else None
+    """
+    try:
+        reldir = subprocess.check_output(
+            ['git', 'rev-parse', '--git-dir'])
+        reldir = reldir.decode('utf-8')
+        return os.path.basename(os.path.dirname(os.path.abspath(reldir)))
+    except subprocess.CalledProcessError:
+        return None

--- a/track/autodetect.py
+++ b/track/autodetect.py
@@ -4,10 +4,13 @@ Hacky, library and usage specific tricks to infer decent defaults.
 import os
 import subprocess
 import sys
+import shlex
+
+from .constants import DFL_DIR_PARENT
 
 def dfl_local_dir():
     """
-    Infers a default local directory, which is ~/track/<project name>,
+    Infers a default local directory, which is DFL_DIR_PARENT/<project name>,
     where the project name is guessed according to the following rules.
 
     If we detect we're in a repository, the project name is the repository name
@@ -23,7 +26,7 @@ def dfl_local_dir():
         project_name = sys.argv[0]
     if not project_name:
         project_name = "unknown"
-    dirpath = os.path.join("~", "track", project_name)
+    dirpath = os.path.join(DFL_DIR_PARENT, project_name)
     return os.path.expanduser(dirpath)
 
 def git_repo():
@@ -37,3 +40,20 @@ def git_repo():
         return os.path.basename(os.path.dirname(os.path.abspath(reldir)))
     except subprocess.CalledProcessError:
         return None
+
+
+def git_hash():
+    """returns the current git hash. must be in git repo"""
+    git_hash = subprocess.check_output(
+        ['git', 'rev-parse', 'HEAD'])
+    # git_hash is a byte string; we want a string.
+    git_hash = git_hash.decode('utf-8')
+    # git_hash also comes with an extra \n at the end, which we remove.
+    git_hash = git_hash.strip()
+    return git_hash
+
+def invocation():
+    """reconstructs the invocation for this python program"""
+    cmdargs = [sys.executable] + sys.argv[:]
+    invocation = ' '.join(shlex.quote(s) for s in cmdargs)
+    return invocation

--- a/track/constants.py
+++ b/track/constants.py
@@ -16,6 +16,9 @@ list file (i.e., not valid json, but valid json on each line),
 and the artifacts folder contains the artifacts as supplied by
 the user.
 """
+import os
+
 METADATA_FOLDER = "trials"
 CONFIG_SUFFIX = "param_map.json"
 RESULT_SUFFIX = "result.json"
+DFL_DIR_PARENT = os.path.join("~", "track")

--- a/track/convenience.py
+++ b/track/convenience.py
@@ -9,6 +9,9 @@ def absl_flags():
     """
     Extracts absl-py flags that the user has specified and outputs their
     key-value mapping.
+
+    By default, extracts only those flags in the current __package__
+    and mainfile.
     """
     # TODO: need same thing for argparse
     from absl import flags

--- a/track/convenience.py
+++ b/track/convenience.py
@@ -1,0 +1,25 @@
+"""
+Miscellaneous helpers for extracting parameters, useful for creating
+Trial param_maps without the hassle of extracting the parameters manually.
+"""
+
+import sys
+
+def absl_flags():
+    """
+    Extracts absl-py flags that the user has specified and outputs their
+    key-value mapping.
+    """
+    # TODO: need same thing for argparse
+    from absl import flags
+    flags_dict = flags.FLAGS.flags_by_module_dict()
+    # only include parameters from modules the user probably cares about
+    def _relevant_module(module_name):
+        if __package__ and __package__ in module_name:
+            return True
+        if module_name == sys.argv[0]:
+            return True
+        return False
+    return {
+        flag.name: flag.value for module, flags in flags_dict.items()
+        for flag in flags if _relevant_module(module)}

--- a/track/convenience.py
+++ b/track/convenience.py
@@ -1,6 +1,7 @@
 """
-Miscellaneous helpers for extracting parameters, useful for creating
-Trial param_maps without the hassle of extracting the parameters manually.
+Miscellaneous helpers for getting some of the arguments to tracking-related
+functions automatically, usually involving parameter extraction in a
+sensible default way from commonly used libraries.
 """
 
 import sys
@@ -12,6 +13,8 @@ def absl_flags():
 
     By default, extracts only those flags in the current __package__
     and mainfile.
+
+    Useful to put into a trial's param_map.
     """
     # TODO: need same thing for argparse
     from absl import flags

--- a/track/convenience.py
+++ b/track/convenience.py
@@ -5,6 +5,7 @@ sensible default way from commonly used libraries.
 """
 
 import sys
+from absl import flags
 
 def absl_flags():
     """
@@ -17,7 +18,6 @@ def absl_flags():
     Useful to put into a trial's param_map.
     """
     # TODO: need same thing for argparse
-    from absl import flags
     flags_dict = flags.FLAGS.flags_by_module_dict()
     # only include parameters from modules the user probably cares about
     def _relevant_module(module_name):

--- a/track/log.py
+++ b/track/log.py
@@ -70,8 +70,9 @@ def debug(s, *args):
     except Exception:  # pylint: disable=broad-except
         pathname = '<UNKNOWN-FILE>.py'
         lineno = 0
-    _FORMATTER.pathname = pathname
-    _FORMATTER.lineno = lineno
+    if _FORMATTER: # log could have not been initialized.
+        _FORMATTER.pathname = pathname
+        _FORMATTER.lineno = lineno
     logger = logging.getLogger(__package__)
     logger.debug(s.format(*args))
 

--- a/track/log.py
+++ b/track/log.py
@@ -1,0 +1,106 @@
+"""
+File adopted from Michael Whittaker.
+
+This module firstly offers a convenience function called "debug" which
+alleviates a couple of inconveniences in python logging:
+
+* No need to find a logger before logging (uses the one from this package)
+* Slightly friendly string interpolation interface.
+"""
+
+from datetime import datetime
+import inspect
+import hashlib
+import subprocess
+import os
+import shlex
+import json
+import sys
+import logging
+
+class TrackLogHandler(logging.FileHandler):
+    """File-based logging handler for the track package"""
+    pass
+
+class StdoutHandler(logging.StreamHandler):
+    """As described by the name"""
+    def __init__(self):
+        super().__init__(sys.stdout)
+
+def init(track_log_handler):
+    """
+    (Re)initialize track's file handler for track package logger.
+
+    Adds a stdout-printing handler automatically.
+    """
+
+    logger = logging.getLogger(__package__)
+
+    # TODO (just document prominently)
+    # assume only one trial can run at once right now
+    # multi-concurrent-trial support will require complex filter logic
+    # based on the currently-running trial (maybe we shouldn't allow multiple
+    # trials on different python threads, that's dumb)
+    to_rm = [h for h in logger.handlers if isinstance(h, TrackLogHandler)]
+    for h in to_rm:
+        logger.removeHandler(h)
+
+    if not any(isinstance(h, StdoutHandler) for h in logger.handlers):
+        handler = StdoutHandler()
+        handler.setFormatter(_FORMATTER)
+        logger.addHandler(handler)
+
+    track_log_handler.setFormatter(_FORMATTER)
+    logger.addHandler(handler)
+
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+def debug(s, *args):
+    """debug(s, x1, ..., xn) logs s.format(x1, ..., xn)."""
+    # Get the path name and line number of the function which called us.
+    previous_frame = inspect.currentframe().f_back
+    try:
+        pathname, lineno, _, _, _ = inspect.getframeinfo(previous_frame)
+        # if path is in cwd, simplify it
+        cwd = os.path.abspath(os.getcwd())
+        pathname = os.path.abspath(pathname)
+        if os.path.commonprefix([cwd, pathname]) == cwd:
+            pathname = os.path.relpath(pathname, cwd)
+    except Exception:  # pylint: disable=broad-except
+        pathname = '<UNKNOWN-FILE>.py'
+        lineno = 0
+    _FORMATTER.pathname = pathname
+    _FORMATTER.lineno = lineno
+    logger = logging.getLogger(__package__)
+    logger.debug(s.format(*args))
+
+class _StackCrawlingFormatter(logging.Formatter):
+    """
+    If we configure a python logger with the format string
+    "%(pathname):%(lineno): %(message)", messages logged via `log.debug` will
+    be prefixed with the path name and line number of the code that called
+    `log.debug`. Unfortunately, when a `log.debug` call is wrapped in a helper
+    function (e.g. debug below), the path name and line number is always that
+    of the helper function, not the function which called the helper function.
+
+    A _StackCrawlingFormatter is a hack to log a different pathname and line
+    number. Simply set the `pathname` and `lineno` attributes of the formatter
+    before you call `log.debug`. See `debug` below for an example.
+    """
+
+    def __init__(self, format_str):
+        super().__init__(format_str)
+        self.pathname = None
+        self.lineno = None
+
+    def format(self, record):
+        s = super().format(record)
+        if self.pathname is not None:
+            s = s.replace('{pathname}', self.pathname)
+        if self.lineno is not None:
+            s = s.replace('{lineno}', str(self.lineno))
+        return s
+
+_FORMAT_STRING = "[%(asctime)-15s {pathname}:{lineno}] %(message)s"
+_FORMATTER = _StackCrawlingFormatter(_FORMAT_STRING)

--- a/track/project.py
+++ b/track/project.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import json
 
-import .constants
+from . import constants
 
 from .sync import S3_PREFIX, GCS_PREFIX, check_remote_util
 

--- a/track/project.py
+++ b/track/project.py
@@ -58,8 +58,8 @@ class Project(object):
             result_file = os.path.join(
                 metadata_folder, trial_id + "_" + constants.RESULT_SUFFIX)
             assert os.path.isfile(result_file), result_file
-            dfs.append(pd.read_json(result_file, typ='frame'))
-        df = pd.concat(rows, axis=0, ignore_index=True)
+            dfs.append(pd.read_json(result_file, typ='frame', lines=True))
+        df = pd.concat(dfs, axis=0, ignore_index=True)
         return df
 
 
@@ -96,8 +96,8 @@ class Project(object):
             if not trial_file.endswith(constants.CONFIG_SUFFIX):
                 continue
             trial_file = os.path.join(metadata_folder, trial_file)
-            rows.append(pd.read_json(trial_file, typ='series'))
-        return pd.concat(rows, axis=1)
+            rows.append(pd.read_json(trial_file, typ='frame', lines=True))
+        return pd.concat(rows, axis=0, ignore_index=True)
 
 def _remote_to_local_sync(remote, local):
     # TODO: at some point look up whether sync will clobber newer

--- a/track/project.py
+++ b/track/project.py
@@ -19,9 +19,11 @@ class Project(object):
     metrics, and then path-based access to stored user artifacts for each trial.
     """
 
-    def __init__(self, log_dir, upload_dir):
+    def __init__(self, log_dir, upload_dir=None):
+        # TODO default log_dir should behave like trial's default log dir
         self.log_dir = log_dir
-        check_remote_util(upload_dir)
+        if upload_dir:
+            check_remote_util(upload_dir)
         self.upload_dir = upload_dir
         self._sync_metadata()
         self._ids = self._load_metadata()
@@ -74,15 +76,17 @@ class Project(object):
         # backslashes but remote dirs will be expecting /
         # TODO: having s3 logic split between project and sync.py
         # worries me
-        remote = '/'.join([self.upload_dir, trial_id, prefix])
         local = os.path.join(self.log_dir, trial_id, prefix)
-        _remote_to_local_sync(remote, local)
+        if self.upload_dir:
+            remote = '/'.join([self.upload_dir, trial_id, prefix])
+            _remote_to_local_sync(remote, local)
         return local
 
     def _sync_metadata(self):
-        remote = '/'.join([self.upload_dir, constants.METADATA_FOLDER])
         local = os.path.join(self.log_dir, constants.METADATA_FOLDER)
-        _remote_to_local_sync(remote, local)
+        if self.upload_dir:
+            remote = '/'.join([self.upload_dir, constants.METADATA_FOLDER])
+            _remote_to_local_sync(remote, local)
 
     def _load_metadata(self):
         metadata_folder = os.path.join(self.log_dir, constants.METADATA_FOLDER)

--- a/track/project.py
+++ b/track/project.py
@@ -11,17 +11,21 @@ import pandas as pd
 from . import constants
 
 from .sync import S3_PREFIX, GCS_PREFIX, check_remote_util
+from .trial import _git_repo
 
 class Project(object):
     """
     The project class manages all trials that have been run with the given
     log_dir and upload_dir. It gives pandas-dataframe access to trial metadata,
     metrics, and then path-based access to stored user artifacts for each trial.
+
+    log_dir is created with the same defaults as in track.Trial
     """
 
-    def __init__(self, log_dir, upload_dir=None):
-        # TODO default log_dir should behave like trial's default log dir
-        # TODO that means also expanduser()
+    def __init__(self, log_dir=None, upload_dir=None):
+        git_repo = _git_repo()
+        if log_dir is None:
+            log_dir = os.path.join("~", "track", git_repo or "unknown")
         self.log_dir = log_dir
         if upload_dir:
             check_remote_util(upload_dir)

--- a/track/project.py
+++ b/track/project.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 import json
 
+import pandas as pd
+
 from . import constants
 
 from .sync import S3_PREFIX, GCS_PREFIX, check_remote_util

--- a/track/project.py
+++ b/track/project.py
@@ -21,6 +21,7 @@ class Project(object):
 
     def __init__(self, log_dir, upload_dir=None):
         # TODO default log_dir should behave like trial's default log dir
+        # TODO that means also expanduser()
         self.log_dir = log_dir
         if upload_dir:
             check_remote_util(upload_dir)
@@ -96,7 +97,7 @@ class Project(object):
                 continue
             trial_file = os.path.join(metadata_folder, trial_file)
             rows.append(pd.read_json(trial_file, typ='series'))
-        self._ids = pd.concat(rows, axis=1)
+        return pd.concat(rows, axis=1)
 
 def _remote_to_local_sync(remote, local):
     # TODO: at some point look up whether sync will clobber newer

--- a/track/project.py
+++ b/track/project.py
@@ -9,9 +9,8 @@ import json
 import pandas as pd
 
 from . import constants
-
+from .autodetect import dfl_local_dir
 from .sync import S3_PREFIX, GCS_PREFIX, check_remote_util
-from .trial import _git_repo
 
 class Project(object):
     """
@@ -23,9 +22,8 @@ class Project(object):
     """
 
     def __init__(self, log_dir=None, upload_dir=None):
-        git_repo = _git_repo()
         if log_dir is None:
-            log_dir = os.path.join("~", "track", git_repo or "unknown")
+            log_dir = dfl_local_dir()
         self.log_dir = log_dir
         if upload_dir:
             check_remote_util(upload_dir)

--- a/track/project.py
+++ b/track/project.py
@@ -43,6 +43,10 @@ class Project(object):
         """
         metadata_folder = os.path.join(self.log_dir, constants.METADATA_FOLDER)
         dfs = []
+        # TODO: various file-creation corner cases like the result file not
+        # always existing if stuff is not logged and etc should be ironed out
+        # (would probably be easier if we had a centralized Sync class which
+        # relied on some formal remote store semantics).
         for trial_id in trial_ids:
             # TODO constants should just contain the recipes for filename
             # construction instead of this multi-file implicit constraint

--- a/track/trial.py
+++ b/track/trial.py
@@ -39,6 +39,7 @@ class Trial(object):
     (2) ~/track/<git repo>, where <git repo> is the name of a git
         repository the cwd is in. If cwd is not in a git repo, then
         <git repo> is set to 'unknown'.
+    (3) TODO: if unknown maybe use sys.argv[0]?
 
     The upload directory may be None (in which case no upload is performed),
     or an S3 directory or a GCS directory.

--- a/track/trial.py
+++ b/track/trial.py
@@ -141,8 +141,10 @@ class Trial(object):
 def _git_repo():
     # returns None if not in a git repo, else the repo root
     try:
-        return os.path.dirname(os.path.abspath(subprocess.check_output(
-            ['git', 'rev-parse', '--git-dir'])))
+        reldir = subprocess.check_output(
+            ['git', 'rev-parse', '--git-dir'])
+        reldir = reldir.decode('utf-8')
+        return os.path.dirname(os.path.abspath(reldir))
     except subprocess.CalledProcessError:
         return None
 

--- a/track/trial.py
+++ b/track/trial.py
@@ -1,10 +1,13 @@
 import os
+import sys, shlex
 from track.logger import UnifiedLogger
 from track.sync import SyncHook
+import subprocess
 import uuid
 import shutil
 from datetime import datetime
-from track.constants import METADATA_FOLDER, RESULT_SUFFIX
+from .constants import METADATA_FOLDER, RESULT_SUFFIX
+from . import log
 
 
 def time_str():
@@ -26,14 +29,34 @@ def flatten_dict(dt):
             del dt[k]
     return dt
 
-
 class Trial(object):
+    """
+    Trial attempts to infer the local log_dir and remote upload_dir
+    automatically.
+
+    In order of precedence, log_dir is determined by:
+    (1) the path passed into the argument of the Trial constructor
+    (2) ~/track/<git repo>, where <git repo> is the name of a git
+        repository the cwd is in. If cwd is not in a git repo, then
+        <git repo> is set to 'unknown'.
+
+    The upload directory may be None (in which case no upload is performed),
+    or an S3 directory or a GCS directory.
+
+    init_logging will automatically set up a logger at the debug level,
+    along with handlers to print logs to stdout and to a persistent store.
+    """
     def __init__(self,
-                 log_dir="~/ray_results/project_name",
+                 log_dir=None,
                  upload_dir=None,
                  sync_period=None,
                  trial_prefix="",
-                 param_map=None):
+                 param_map=None,
+                 init_logging=True):
+        git_repo = _git_repo()
+        if log_dir is None:
+            log_dir = os.path.join("~", "track", git_repo or "unknown")
+
         base_dir = os.path.expanduser(log_dir)
         self.base_dir = base_dir
         self.data_dir = os.path.join(base_dir, METADATA_FOLDER)
@@ -45,7 +68,29 @@ class Trial(object):
         self.artifact_dir = os.path.join(base_dir, self.trial_id)
         self.upload_dir = upload_dir
         self.param_map = param_map or {}
+
+        # misc metadata to save as well
         self.param_map["trial_id"] = self.trial_id
+        self.param_map["git_repo"] = git_repo or "unknown"
+        self.param_map["git_hash"] = _git_hash() if git_repo else "unknown"
+        self.param_map["start_time"] = datetime.now().isoformat()
+        self.param_map["invocation"] = _invocation()
+        self.param_map["trial_completed"] = False
+
+        if init_logging:
+            log.init(self.logging_handler())
+
+
+    def logging_handler(self):
+        """
+        For advanced logging setups, returns a file-based log handler
+        pointing to a log.txt artifact.
+
+        If you use init_logging = True there is no need to call this
+        method.
+        """
+        return log.TrackLogHandler(
+            os.path.join(self.artifact_dir, 'log.txt'))
 
     def start(self):
         for path in [self.base_dir, self.data_dir, self.artifact_dir]:
@@ -84,6 +129,34 @@ class Trial(object):
     def close(self):
         for hook in self._hooks:
             hook.close()
+        # unsure if editting the param_map file like this is very kosher
+        self.param_map["trial_completed"] = True
+        # using a constructor for its side effect here (updating the param map)
+        UnifiedLogger(
+            self.param_map, self.data_dir, self.trial_id + "_").close()
 
     def get_result_filename(self):
         return os.path.join(self.data_dir, self.trial_id + "_" + RESULT_SUFFIX)
+
+def _git_repo():
+    # returns None if not in a git repo, else the repo root
+    try:
+        return os.path.dirname(subprocess.check_output(
+            ['git', 'rev-parse', '--git-dir']))
+    except subprocess.CalledProcessError:
+        return None
+
+def _git_hash():
+    # returns the current git hash. must be in git repo
+    git_hash = subprocess.check_output(
+        ['git', 'rev-parse', 'HEAD'])
+    # git_hash is a byte string; we want a string.
+    git_hash = git_hash.decode('utf-8')
+    # git_hash also comes with an extra \n at the end, which we remove.
+    git_hash = git_hash.strip()
+    return git_hash
+
+def _invocation():
+    cmdargs = [sys.executable] + sys.argv[:]
+    invocation = ' '.join(shlex.quote(s) for s in cmdargs)
+    return invocation

--- a/track/trial.py
+++ b/track/trial.py
@@ -141,8 +141,8 @@ class Trial(object):
 def _git_repo():
     # returns None if not in a git repo, else the repo root
     try:
-        return os.path.dirname(subprocess.check_output(
-            ['git', 'rev-parse', '--git-dir']))
+        return os.path.dirname(os.path.abspath(subprocess.check_output(
+            ['git', 'rev-parse', '--git-dir'])))
     except subprocess.CalledProcessError:
         return None
 

--- a/track/trial.py
+++ b/track/trial.py
@@ -37,10 +37,7 @@ class Trial(object):
 
     In order of precedence, log_dir is determined by:
     (1) the path passed into the argument of the Trial constructor
-    (2) ~/track/<git repo>, where <git repo> is the name of a git
-        repository the cwd is in. If cwd is not in a git repo, then
-        <git repo> is set to 'unknown'.
-    (3) TODO: if unknown maybe use sys.argv[0]?
+    (2) autodetect.dfl_local_dir()
 
     The upload directory may be None (in which case no upload is performed),
     or an S3 directory or a GCS directory.

--- a/track/trial.py
+++ b/track/trial.py
@@ -144,7 +144,6 @@ def _git_repo():
         reldir = subprocess.check_output(
             ['git', 'rev-parse', '--git-dir'])
         reldir = reldir.decode('utf-8')
-        print(os.path.dirname(os.path.abspath(reldir)))
         return os.path.basename(os.path.dirname(os.path.abspath(reldir)))
     except subprocess.CalledProcessError:
         return None

--- a/track/trial.py
+++ b/track/trial.py
@@ -89,6 +89,7 @@ class Trial(object):
         If you use init_logging = True there is no need to call this
         method.
         """
+        os.makedirs(self.artifact_dir, exist_ok=True)
         return log.TrackLogHandler(
             os.path.join(self.artifact_dir, 'log.txt'))
 

--- a/track/trial.py
+++ b/track/trial.py
@@ -144,7 +144,8 @@ def _git_repo():
         reldir = subprocess.check_output(
             ['git', 'rev-parse', '--git-dir'])
         reldir = reldir.decode('utf-8')
-        return os.path.dirname(os.path.abspath(reldir))
+        print(os.path.dirname(os.path.abspath(reldir)))
+        return os.path.basename(os.path.dirname(os.path.abspath(reldir)))
     except subprocess.CalledProcessError:
         return None
 

--- a/track/trial.py
+++ b/track/trial.py
@@ -66,6 +66,7 @@ class Trial(object):
 
         self._sync_period = sync_period
         self.artifact_dir = os.path.join(base_dir, self.trial_id)
+        os.makedirs(self.artifact_dir, exist_ok=True)
         self.upload_dir = upload_dir
         self.param_map = param_map or {}
 
@@ -79,6 +80,8 @@ class Trial(object):
 
         if init_logging:
             log.init(self.logging_handler())
+            log.debug("(re)initilized logging")
+
 
 
     def logging_handler(self):
@@ -89,7 +92,6 @@ class Trial(object):
         If you use init_logging = True there is no need to call this
         method.
         """
-        os.makedirs(self.artifact_dir, exist_ok=True)
         return log.TrackLogHandler(
             os.path.join(self.artifact_dir, 'log.txt'))
 
@@ -120,12 +122,9 @@ class Trial(object):
         for hook in self._hooks:
             hook.on_result(new_args)
 
-    def artifact(self, artifact_name, src):
-        srcpath = os.path.expanduser(src)
-        # Copy filepath to the base_dir
-        destpath = os.path.join(self.artifact_dir, artifact_name)
-        os.path.makedirs(os.path.dirname(artifact_name), exist_ok=True)
-        shutil.copy(srcpath, destpath)
+    def artifact_directory(self):
+        """returns the local file path to the trial's artifact directory"""
+        return self.artifact_dir
 
     def close(self):
         for hook in self._hooks:

--- a/track/trials.py
+++ b/track/trials.py
@@ -1,0 +1,87 @@
+"""
+This module can be run as a python script when track is installed like so:
+
+python -m trials --local_dir ~/track/myproject
+
+The module prints the trial UUIDs that are available in the specified local
+or remote directories.
+
+By default, this prints all available trials sorted by start time, but just
+the trial_ids. We allow rudimentary filtering. For example, suppose all
+trials in the default local directory (see track.autodetect.dfl_local_dir) are
+summarized by
+
+$ python -m track.trials
+trial_id    start_time                 git_hash
+8424fb387a 2018-06-28 11:17:28.752259  f573f57cef01316ab6b6af0d73efac9e7ba1f415
+6187e7bc7a 2018-06-27 18:27:11.635714  f573f57cef01316ab6b6af0d73efac9e7ba1f415
+14b0ed447a 2018-06-27 18:25:02.718893  f573f57cef01316ab6b6af0d73efac9e7ba1f415
+
+The default prints the above columns sorted by start time. We can ask for
+parameters on the command line.
+
+$ python -m track.trials learning_rate
+learning_rate
+0.1
+0.1
+0.1
+
+$ python -m track.trials learning_rate "start_time>2018-06-28"
+learning_rate start_time
+0.1           2018-06-28 11:17:28.752259
+
+In other words, only included columns are printed.
+"""
+
+from absl import flags
+from absl import app
+import pandas as pd
+
+from . import Project
+
+flags.DEFINE_string("local_dir", None,
+                          "the local directory where trials are stored "
+                          "for default behavior see "
+                          "track.autodetect.dfl_local_dir")
+flags.DEFINE_string("remote_dir", None,
+                          "the remote directory where trials are stored")
+
+def compare(c, l, r):
+    if c == '=':
+        return l == r
+    elif c == '<':
+        return l < r
+    elif c == '>':
+        return l > r
+    else:
+        raise ValueError('unknown operator ' + c)
+
+def _parse_pandas(lit):
+    df = pd.read_json('{{"0": "{}"}}'.format(lit), typ="series")
+    return df[0]
+
+def _main(argv):
+    proj = Project(flags.FLAGS.local_dir, flags.FLAGS.remote_dir)
+    argv = argv[1:]
+    cols = []
+    df = proj.ids
+    conds = '<>='
+    for arg in argv:
+        if not any(c in arg for c in conds):
+            cols.append(arg)
+            continue
+        for c in conds:
+            if c not in arg:
+                continue
+            col, lit = arg.split(c)
+            cols.append(col)
+            lit = _parse_pandas(lit)
+            df = df[compare(c, df[col], lit)]
+    df = df.sort_values("start_time", ascending=False)
+    if not cols:
+        cols = ["trial_id", "start_time", "git_hash"]
+    print(df[cols].to_string(index=False, justify='left'))
+
+
+if __name__ == '__main__':
+    app.run(_main)


### PR DESCRIPTION
* auto-infer params when user uses gflags
* infer local dir from git repo name
* added context-based global trial interface
* provide `artifact_directory` interface instead of the file-based save artifact interface
* added automatic logging utilities
* misc bugfixes to make local dir stuff work
* console-based browser for trials added

Tested manually on local directory mode.